### PR TITLE
Add moduleID reference for ModuleIgnitionEngineController in case of MultiModeEngine

### DIFF
--- a/GameData/ChemicalPropulsion/Patches/Ignition/chemical-propulsion-Ignition-switch-subtypes.cfg
+++ b/GameData/ChemicalPropulsion/Patches/Ignition/chemical-propulsion-Ignition-switch-subtypes.cfg
@@ -469,6 +469,7 @@
 				IDENTIFIER
 				{
 					name = ModuleIgnitionEngineController
+					moduleID = #$/MODULE[ModuleIgnitionEngineController]:HAS[#moduleID[chemTech*Oxidizer]]/moduleID$
 				}
 				DATA
 				{


### PR DESCRIPTION
Fix for #39 and #35 -- assumes that a MultiModeEngine will have exactly two modes, one using oxidizer (closed-cycle) and one using intake air (air-breathing). Targeting the engine controller that `HAS[#moduleID[chemTech*Oxidizer]` will pick the closed-cycle controller if one exists, else silently default to the (only) engine controller.