### PR TITLE
Bugfix #38

### DIFF
--- a/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-ConfigurableContainers.cfg
+++ b/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-ConfigurableContainers.cfg
@@ -30,7 +30,7 @@
 @PART:HAS[~chemTechTankType,!RESOURCE[LqdHydrogen],@MODULE[ModuleTankManager]:HAS[@TANK:HAS[#TankType[LiquidChemicals],#CurrentResource[LqdHydrogen]]]]:NEEDS[ConfigurableContainers]:BEFORE[zz_ChemicalPropulsion]
 {
 	// ModuleTankManager pure LqdHydrogen tank
-	chemTechTankType = aviation
+	chemTechTankType = cryogenic
 }
 @PART:HAS[!RESOURCE[LqdHydrogen],@MODULE[ModuleTankManager]:HAS[@TANK:HAS[#TankType[LiquidChemicals],#CurrentResource[LqdHydrogen]]]]:NEEDS[ConfigurableContainers]:FOR[zz_ChemicalPropulsion]
 {

--- a/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Squad.cfg
+++ b/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Squad.cfg
@@ -370,7 +370,7 @@
 }
 
 // Fuel tanks
-@PART[externalTankCapsule,externalTankRound,externalTankToroid]:BEFORE[zz_ChemicalPropulsion]
+@PART[externalTankCapsule,externalTankRound,externalTankToroid]:FIRST
 {
 	chemTechTankType = cryogenic
 }

--- a/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Squad.cfg
+++ b/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Squad.cfg
@@ -378,8 +378,9 @@
 {
 	chemTechTankVolumePropellant = #$chemTechTankVolumeFuelOxidizer$
 	-chemTechTankVolumeFuelOxidizer = _
-	chemTechTankCostPropellant = #$chemTechTankCostFuelOxidizer$
-	-chemTechTankCostFuelOxidizer = _
+	chemTechTankCostPropellant = #$chemTechTankVolumePropellant$
+	@chemTechTankCostPropellant *= #$@RESOURCE_DEFINITION[LqdHydrogen]/unitCost$
+	@chemTechTankVolumePropellant /= 1.5
 	chemTechTankMassPropellant = #$chemTechTankMassFuelOxidizer$
 	-chemTechTankMassFuelOxidizer = _
 }


### PR DESCRIPTION
Fix #38 issue

- found typo in [Patches/Compatibility/chemical-propulsion-ConfigurableContainers.cfg](https://github.com/CharleRoger/ChemicalPropulsion/compare/main...jvosk:ChemicalPropulsion:bugfix-ConfigurableContainersCompatPatching?expand=1#diff-0476bb18fad6089730dde30cb2e067d5d64f168bb4a5b2d4631c1b88e8f32291)
- moved `@PART[externalTankCapsule,externalTankRound,externalTankToroid]` to `FIRST` instead of `BEFORE[zz_ChemicalPropulsion]` so that it assigns `cryogenic` before [compat-patch for ConfigurableContainers](https://github.com/CharleRoger/ChemicalPropulsion/blob/ed8a281333bce1daf37af8f8bbdecee45f502a19/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-ConfigurableContainers.cfg#L2-L6) assigns `bipropellant`
- added direct calculation of `chemTechTankCostPropellant` referencing [Patches/Misc/chemical-propulsion-tanks.cfg](https://github.com/CharleRoger/ChemicalPropulsion/blob/ed8a281333bce1daf37af8f8bbdecee45f502a19/GameData/ChemicalPropulsion/Patches/Misc/chemical-propulsion-tanks.cfg#L90-L98)