### PR TITLE
fix: replace unsafe FOR block with AFTER to prevent ghost dependencies

### DIFF
--- a/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Kerbalism.cfg
+++ b/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Kerbalism.cfg
@@ -289,7 +289,7 @@ Profile
 		}
 	}
 }
-@PART:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch],@SUBTYPE[Oxygen],@SUBTYPE[Nitrogen],@SUBTYPE[Hydrogen],@SUBTYPE[Ammonia],@SUBTYPE[CarbonDioxide],@SUBTYPE[XenonGas]]]:FOR[zzzKerbalismDefault]
+@PART:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch],@SUBTYPE[Oxygen],@SUBTYPE[Nitrogen],@SUBTYPE[Hydrogen],@SUBTYPE[Ammonia],@SUBTYPE[CarbonDioxide],@SUBTYPE[XenonGas]]]:AFTER[zzzKerbalismDefault]
 {
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch],@SUBTYPE[Oxygen],@SUBTYPE[Nitrogen],@SUBTYPE[Hydrogen],@SUBTYPE[Ammonia],@SUBTYPE[CarbonDioxide],@SUBTYPE[XenonGas]]
 	{


### PR DESCRIPTION
Replaces :FOR[zzzKerbalismDefault] with :AFTER[zzzKerbalismDefault] on the B9 fuelSwitch patch in order to be in line with Module Manager good practices and prevent any false-positives in case someone writes a patch that checks for zzzKerbalismDefault explicitly.