### PR TITLE
Fix BluedogDB identifier

### DIFF
--- a/GameData/ChemicalPropulsion/ChemicalPropulsion.ckan
+++ b/GameData/ChemicalPropulsion/ChemicalPropulsion.ckan
@@ -16,7 +16,7 @@ depends:
 recommends:
   - name: ChemicalTechTree
   - name: AlcoholicAeronautics
-  - name: BluedogDesignBureau
+  - name: BluedogDB
   - name: CryoEngines
   - name: CryoTanks
   - name: KerbalAtomics


### PR DESCRIPTION
Hi @CharleRoger,

`BluedogDB` has an abbreviation in its identifier, unfortunately. This mod's .ckan file has it unabbreviated, and this PR fixes that.

Noticed while investigating KSP-CKAN/CKAN#4673, oddly enough.

<img width="631" height="484" alt="image" src="https://github.com/user-attachments/assets/883d6835-6279-4f82-b951-e33ae523783f" />

Cheers!
