### PR TITLE
Fix BluedogDB cargo containers being deleted

### DIFF
--- a/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Bluedog_DB.cfg
+++ b/GameData/ChemicalPropulsion/Patches/Compatibility/chemical-propulsion-Bluedog_DB.cfg
@@ -174,11 +174,11 @@
 }
 
 // Some trickier tank volume cases
-@PART[bluedog_*]:HAS[~chemTechTankVolumeFuelOxidizer,@MODULE[ModuleB9PartSwitch]:HAS[#baseVolume,~baseVolume[0],!SUBTYPE:HAS[~tankType],@SUBTYPE:HAS[#tankType[bdb*]]]]:AFTER[zz_ChemicalPropulsion]
+@PART[bluedog_*]:HAS[~chemTechTankVolumeFuelOxidizer,@MODULE[ModuleB9PartSwitch]:HAS[#baseVolume,~baseVolume[0],~moduleID[cargoSwitch],!SUBTYPE:HAS[~tankType],@SUBTYPE:HAS[#tankType[bdb*]]]]:AFTER[zz_ChemicalPropulsion]
 {
-	%chemTechTankVolumeFuelOxidizer = #$MODULE[ModuleB9PartSwitch]:HAS[#baseVolume,~baseVolume[0],!SUBTYPE:HAS[~tankType],@SUBTYPE:HAS[#tankType[bdb*]]]/baseVolume$
+	%chemTechTankVolumeFuelOxidizer = #$MODULE[ModuleB9PartSwitch]:HAS[#baseVolume,~baseVolume[0],~moduleID[cargoSwitch],!SUBTYPE:HAS[~tankType],@SUBTYPE:HAS[#tankType[bdb*]]]/baseVolume$
 	@chemTechTankVolumeFuelOxidizer *= 5
-	-MODULE[ModuleB9PartSwitch]:HAS[#baseVolume,~baseVolume[0],~moduleID[engineSwitch],!SUBTYPE:HAS[~tankType],@SUBTYPE:HAS[#tankType[bdb*]]] {}
+	-MODULE[ModuleB9PartSwitch]:HAS[#baseVolume,~baseVolume[0],~moduleID[engineSwitch],~moduleID[cargoSwitch],!SUBTYPE:HAS[~tankType],@SUBTYPE:HAS[#tankType[bdb*]]] {}
 }
 @PART[bluedog_DeltaE_Tank,bluedog_DeltaK_Stage,bluedog_DeltaIV_DCSS_5m,bluedog_DCSS_Tank,bluedog_Vanguard_S2_Tank,bluedog_Vega_EngineMount,bluedog_Vega_ThirdStage_Tank,bluedog_Centaur_Kickstage,bluedog_Gemini_LanderCan,bluedog_Gemini_Capsule,bluedog_BigG_Cabin,bluedog_Apollo_CrewPod,bluedog_Apollo_CrewPod_5crew,bluedog_Apollo_RCML,bluedog_Apollo_RCML,bluedog_LM_Ascent_Cockpit,bluedog_LM_Taxi,bluedog_LM_Shelter,bluedog_LM_Lab,bluedog_EarlyLunarShelter,bluedog_LM_SheLab,bluedog_Ablestar_Tank,bluedog_voyagerMarsOrbiter_propulsionModule]
 {


### PR DESCRIPTION
For https://github.com/CharleRoger/ChemicalPropulsion/issues/57
Exclude part switch tanks with "cargoSwitch" moduleID
Parts that contain Ore resource will eventually be converted into a B9PartSwitch module that can contain Ore, life support supplies, materialkits, etc. Ignore this when patching fuel tanks.

Example of patched part:
[bluedog_GeminiFerry_PressurizedModule.cfg.txt](https://github.com/user-attachments/files/29891073/bluedog_GeminiFerry_PressurizedModule.cfg.txt)
